### PR TITLE
Removing URL-encoding of branch names when creating root dir

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -485,7 +485,7 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 		}
 
 		// All others are branches
-		return new File(getBranchesDir(), Util.rawEncode(child.getName()));
+		return new File(getBranchesDir(), child.getName());
 	}
 
 	/**


### PR DESCRIPTION
Since URL-encoding of branch directory name is causing issues to some people, me included (specifically, the code I'm running in unit tests is having issues with percent-encoded file names), I've tried to simply remove it. 

Since it seems to work perfectly, so far, without the encoding, I decided to create a PR for it. Maybe it will just work for others too. 

I have tried it on Linux - I have no idea what will happen on Windows. 