### PR TITLE
Jenkins 34076 - Stop ignoring all branches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>5.1</version>
+            <version>5.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>

--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -590,11 +590,6 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
             P project = observer.shouldUpdate(branchNameEncoded);
 
-            if (!observer.mayCreate(branchNameEncoded) && !observer.shouldUpdate(branchNameEncoded)) {
-                listener.getLogger().println("Ignoring " + branchNameEncoded + " (should not be created or updated)");
-                continue;
-            }
-
             try {
                 if (project == null) {
                     listener.getLogger().println("Creating project for branch " + branchNameEncoded);

--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -590,8 +590,8 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
             P project = observer.shouldUpdate(branchNameEncoded);
 
-            if (!observer.mayCreate(branchNameEncoded)) {
-                listener.getLogger().println("Ignoring duplicate " + branchNameEncoded);
+            if (!observer.mayCreate(branchNameEncoded) && !observer.shouldUpdate(branchNameEncoded)) {
+                listener.getLogger().println("Ignoring " + branchNameEncoded + " (should not be created or updated)");
                 continue;
             }
 

--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -592,6 +592,11 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
             try {
                 if (project == null) {
+                    if (!observer.mayCreate(branchNameEncoded)) {
+                        listener.getLogger().println("Skipping creation for '" + branchNameEncoded + "' - mayCreate returned false");
+                        continue;
+                    }
+
                     listener.getLogger().println("Creating project for branch " + branchNameEncoded);
 
                     project = createNewSubProject(this, branchNameEncoded);


### PR DESCRIPTION
The changes to to folder-plugin for Jenkins-32179 result in all branches being ignored. Since the creation check is performed later anyway, mayCreate() does not need to be called.