### PR TITLE
Add option to disable updating configuration of existing sub-projects

### DIFF
--- a/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-details.jelly
+++ b/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject/configure-details.jelly
@@ -30,7 +30,7 @@ THE SOFTWARE.
     <f:block>
         <hr/>
         <h3>${%Branch Management}</h3>
-        <p>Describes how sub-projects are created based on available SCM branches.</p>
+        <p>Describes how sub-projects are created or updated based on available SCM branches.</p>
         <hr/>
     </f:block>
 
@@ -41,6 +41,10 @@ THE SOFTWARE.
     <f:optionalBlock field="suppressTriggerNewBranchBuild"
                      title="${%Suppress automatic build trigger after discovering new branches}"
                      checked="${it.suppressTriggerNewBranchBuild}"/>
+
+		<f:optionalBlock field="suppressUpdatingConfigOfExistingProjects"
+                     title="${%Do not update configuration of existing sub-projects}"
+                     checked="${it.suppressUpdatingConfigOfExistingProjects}"/>
 
     <st:include page="configure-scm"/>
 


### PR DESCRIPTION
This PR adds an option to not update configuration of existing sub-projects into Multi-branch project configuration.

## Screenshot
![multi-branch-suppress-update](https://cloud.githubusercontent.com/assets/885946/14940952/5bb12b22-0f8b-11e6-9e7b-9bcb58542862.png)

## Advantages of not syncing sub-project's configuration
* If you change the build process and it is not compatible with your old branches, you can still build them.
* You can change the configurations of a single branch manually and it does not get overwritten on every sync.

## Disadvantage of not syncing sub-project's configuration
* If you rebase your branch and the project configuration needs change (e.g. build process changed) the configuration does not get updated automatically. (You have to change the configuration manually. Or you can delete the sub-project and let sync to create it again - if you do not mind loosing workspace or build history.)