### PR TITLE
Fix incompatiblity with Python program

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/AbstractMultiBranchProject.java
@@ -218,7 +218,7 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
             if (getItem(disabledSubProject) == null) {
                 // Didn't find item, so don't add it to new list
                 // Do we have the encoded item though?
-                String encoded = Util.rawEncode(disabledSubProject);
+                String encoded = Util.rawEncode(disabledSubProject.replace("-", "--").replace("/", "-"));
 
                 if (getItem(encoded) != null) {
                     // Found encoded item, add encoded name to new list
@@ -584,7 +584,12 @@ public abstract class AbstractMultiBranchProject<P extends AbstractProject<P, B>
 
         for (SCMHead head : heads) {
             String branchName = head.getName();
-            String branchNameEncoded = Util.rawEncode(branchName);
+            //Branch name with "/" will be replaced with "-", since "/" would be
+            //"%2F" after Util.rawEncode which is not compatible with many
+            //python applications
+            String replacedName = branchName.replace("-", "--").replace("/", "-");
+
+            String branchNameEncoded = Util.rawEncode(replacedName);
 
             listener.getLogger().println("Branch " + branchName + " encoded to " + branchNameEncoded);
 


### PR DESCRIPTION
If branch name contains `/`, it would be encoded to `%2F` in current
implementation. But as for Python `%2F` is a presentation type when presented
in a string: it stands a floating point number to be formatted.

Many Python based program cannot work well with this plugin if branch name
contains "/"

So this fix tries to replace `/` with `-` to avoid many potential failure.
I have *tested it again and again* in our environment