### PR TITLE
Jenkins-32322: Speed up Jenkins lanuch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Desktop.ini
 # JRebel
 rebel.xml
 
+/bin/


### PR DESCRIPTION
Avoid traversing into archive & builds directories when migrating, as these will not contain config.xml, and can be expensive to walk.