### PR TITLE
Add custom workspace entries

### DIFF
--- a/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/MatrixMultiBranchProject/configure-branch-entries.jelly
+++ b/src/main/resources/com/github/mjdetullio/jenkins/plugins/multibranch/MatrixMultiBranchProject/configure-branch-entries.jelly
@@ -29,6 +29,17 @@ THE SOFTWARE.
     <j:set var="descriptor" value="${it.descriptor}"/>
     <j:set var="instance" value="${it}"/>
 
+    <f:advanced>
+      <p:config-customWorkspace />
+      <f:optionalBlock name="hasChildCustomWorkspace" title="${%Use custom child workspace}"
+                       checked="${instance.hasChildCustomWorkspace()}"
+                       help="/help/project-config/custom-workspace.html" inline="true">
+        <f:entry title="${%Child Directory}" field="childCustomWorkspace">
+          <f:textbox />
+        </f:entry>
+      </f:optionalBlock>
+    </f:advanced>
+
     <f:section title="${%Configuration Matrix}">
         <!-- Needed for LabelAxis, but including these from LabelAxis/config.jelly is too late -->
         <l:yui module="treeview" />


### PR DESCRIPTION
This adds the controls for custom workspaces to the Matrix Multibranch projects.

I'm not 100% happy with this solution, as it ends up with 2 "Advanced" buttons, but it's not clear how else this can be resolved without significant restructuring.